### PR TITLE
refactor: expand cursor animation options (size/gradient/combined) and simplify setup

### DIFF
--- a/packages/h5/cursoranimation.ts
+++ b/packages/h5/cursoranimation.ts
@@ -1,3 +1,5 @@
+import type { CursorAnimationOptions } from '../../src/types'
+
 export const beforePoint = (cb) => {
   return new Promise((resolve) => {
     requestAnimationFrame(async () => {
@@ -9,7 +11,46 @@ export interface AnimationOut {
   stopCursorAnimation: () => void
   startCursorAnimation: () => void
 }
-export function setcursoranimation(cursor: HTMLElement | null, opts: { speed?: number } = {}): AnimationOut {
+interface CursorAnimationConfig {
+  speed?: number
+  animation?: CursorAnimationOptions
+}
+
+const translateToken = 'var(--untyper-cursor-translate, -0.05em)'
+
+const buildKeyframes = (kind: CursorAnimationOptions['kind'], options: CursorAnimationOptions = {}): Keyframe[] => {
+  const minScale = options.size?.minScale ?? 0.7
+  const maxScale = options.size?.maxScale ?? 1.15
+  const frames: Keyframe[] = [
+    { opacity: 1, offset: 0 },
+    { opacity: 0.2, offset: 0.5 },
+    { opacity: 1, offset: 1 },
+  ]
+  if (kind === 'size' || kind === 'combined') {
+    frames[0] = { ...frames[0], transform: `translateX(${translateToken}) scaleY(${minScale})` }
+    frames[1] = { ...frames[1], transform: `translateX(${translateToken}) scaleY(${maxScale})` }
+    frames[2] = { ...frames[2], transform: `translateX(${translateToken}) scaleY(${minScale})` }
+  }
+  if (kind === 'gradient' || kind === 'combined') {
+    frames[0] = { ...frames[0], backgroundPosition: '0% 50%' }
+    frames[1] = { ...frames[1], backgroundPosition: '100% 50%' }
+    frames[2] = { ...frames[2], backgroundPosition: '0% 50%' }
+  }
+  return frames
+}
+
+const applyGradientStyles = (cursor: HTMLElement, options: CursorAnimationOptions) => {
+  const angle = options.gradient?.angle ?? 90
+  const from = options.gradient?.from ?? '#5eead4'
+  const to = options.gradient?.to ?? '#6366f1'
+  cursor.style.backgroundImage = `linear-gradient(${angle}deg, ${from}, ${to})`
+  cursor.style.backgroundSize = '200% 200%'
+  cursor.style.backgroundClip = 'text'
+  cursor.style.webkitBackgroundClip = 'text'
+  cursor.style.color = 'transparent'
+}
+
+export function setcursoranimation(cursor: HTMLElement | null, opts: CursorAnimationConfig = {}): AnimationOut {
   const random = () => Math.random().toString().substring(2, 9)
   if (!window.Animation) {
     console.warn('Browser does not support Animation')
@@ -19,14 +60,18 @@ export function setcursoranimation(cursor: HTMLElement | null, opts: { speed?: n
     }
   }
   // TODO
-  const { speed } = opts
-  const animation = cursor!.animate([0, 0, 1].map((n) => {
-    return { opacity: n }
-  }), {
+  const { speed, animation: animationOptions = {} } = opts
+  cursor!.style.transition = 'opacity 150ms ease-in-out'
+  const baseDuration = Math.min(Math.max((speed ?? 150) * 6, 600), 1400)
+  const duration = animationOptions.duration ?? baseDuration
+  const kind = animationOptions.kind ?? 'opacity'
+  if (kind === 'gradient' || kind === 'combined')
+    applyGradientStyles(cursor!, animationOptions)
+  const animation = cursor!.animate(buildKeyframes(kind, animationOptions), {
     iterations: Infinity,
     easing: 'ease-in-out',
     fill: 'forwards',
-    duration: 900,
+    duration,
   })
   if (animation) {
     animation.pause()
@@ -35,7 +80,7 @@ export function setcursoranimation(cursor: HTMLElement | null, opts: { speed?: n
   }
   const stopCursorAnimation = () => {
     cursor!.style.opacity = '1'
-    animation.cancel()
+    animation.pause()
   }
   const startCursorAnimation = () => {
     beforePoint(async () => {
@@ -49,4 +94,3 @@ export function setcursoranimation(cursor: HTMLElement | null, opts: { speed?: n
     startCursorAnimation,
   }
 }
-

--- a/packages/h5/queue.ts
+++ b/packages/h5/queue.ts
@@ -1,7 +1,7 @@
 import type { QueueItem, QueueItems } from '../../src/types'
 export function Queue(initialItems: QueueItem[]): QueueItems {
-  const _q = new Map()
-  function add(steps: QueueItem[] | QueueItem): typeof Queue {
+  const _q = new Map<symbol, QueueItem>()
+  function add(steps: QueueItem[] | QueueItem): QueueItems {
     if (typeof steps === 'object' && !Array.isArray(steps))
       steps = [steps]
     steps.forEach((step) => {
@@ -14,7 +14,7 @@ export function Queue(initialItems: QueueItem[]): QueueItems {
   }
   const getQueue = () => _q
   add(initialItems)
-  const cleanup = (key: Symbol) => {
+  const cleanup = (key: symbol) => {
     _q.delete(key)
   }
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
  * type add delete pause move go
  */
 export interface UnTyperAnimate {
-  cancel: Boolean
+  cancel: boolean
 }
 export interface QueueItem {
   char?: string
@@ -14,6 +14,7 @@ export interface ScopeData {
   startDelay?: number
   animationspancontent?: string
   animate?: UnTyperAnimate
+  cursorAnimation?: CursorAnimationOptions
 }
 
 export interface ActionOpts {
@@ -21,11 +22,27 @@ export interface ActionOpts {
   to?: 'start' | 'end'
 }
 
+export type CursorAnimationKind = 'opacity' | 'size' | 'gradient' | 'combined'
+
+export interface CursorAnimationOptions {
+  kind?: CursorAnimationKind
+  duration?: number
+  size?: {
+    minScale?: number
+    maxScale?: number
+  }
+  gradient?: {
+    from?: string
+    to?: string
+    angle?: number
+  }
+}
+
 export interface QueueItems {
-  add: (steps: QueueItem[] | QueueItem) => any
-  getQueue: () => any
-  getKey: () => any
-  cleanup: (key: Symbol) => any
+  add: (steps: QueueItem[] | QueueItem) => QueueItems
+  getQueue: () => Map<symbol, QueueItem>
+  getKey: () => symbol[]
+  cleanup: (key: symbol) => void
 }
 
 export interface ParsehtmlIn {
@@ -41,4 +58,3 @@ export interface ParsehtmlOut {
   nodeName: string
   func: () => string
 }
-


### PR DESCRIPTION
### Motivation
- Make the internal cursor animation API easier to configure and extend by introducing a compact options object for different transition kinds (opacity, size, gradient, combined).  
- Support visual enhancements like gradient animated backgrounds and size (scale) pulsing without breaking cursor positioning.  
- Surface animation configuration to the UnTyper scope so consumers can control cursor behavior via `ScopeData`.  
- Improve type safety and internal bookkeeping for queue and cursor lifecycle operations.

### Description
- Added `CursorAnimationOptions` and `CursorAnimationKind` to `src/types.ts` and exposed `cursorAnimation` on `ScopeData`.  
- Reworked `packages/h5/cursoranimation.ts` to use `buildKeyframes` and `applyGradientStyles`, computed `duration`, support `kind` (`opacity|size|gradient|combined`), and use a CSS variable token for horizontal translation.  
- Updated `src/untyper.ts` to preserve cursor translation via `--untyper-cursor-translate`, forward `cursorAnimation` to `setcursoranimation`, tighten several method signatures and internal maps/sets, and improve queue/hash bookkeeping.  
- Strengthened queue typings in `packages/h5/queue.ts` and replaced some loose `any`/`Symbol` usages with concrete `Map<symbol, QueueItem>` and `symbol`-typed keys.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c6852940832e9f9f62da9d91c3fc)