### PR TITLE
Add image and element animation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,74 +6,142 @@
 ![untyper](./gif/Kapture%202022-10-14%20at%2014.22.02.gif)
 
 ## [Live demo](https://stackblitz.com/edit/vitejs-vite-2qxcej?file=main.js)
-A simple typewriter for browser,Typing effects can be achieved using chained methods
+A typewriter utility for the browser. It builds a queue of actions so you can chain `type`, `pause`, `delete`, `move`, `add`, `image`, and then run them with `go()`.
 
-## 🛹 &nbsp;TODO
-- [x] support custom typing effect
-- [x] support custom cursor
-- [x] support move cursor
-- [x] support add any document node
-- ...
+## 🚀 Features
+- Chained typing actions powered by the Web Animations API cursor
+- Customizable typing speed, start delay, and cursor animation
+- Supports plain text typing as well as inserting HTML elements and images
+- Optional per-element animations when inserting DOM nodes
+- Works with any DOM element
 
-## 🚀&nbsp; Feature
-  1. use [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Animation) Api to achieve typing effect
-  2. Support custom typing speed
-  3. Support chained methods
-  
-## 📦&nbsp; Install
+## 📦 Install
 
 ```bash
-  npm install untyper
+npm install untyper
 ```
 
-# Usage
+## Usage
 
 ```ts
 import { UnTyper } from 'untyper'
-const text = document.querySelector('#text')
-const unTyper = new UnTyper(text, { speed: 100, startDelay: 1000 })
-unTyper.type('hi', { delay: 200 }).go()
 
+const target = document.querySelector('#text')
+const typer = new UnTyper(target, {
+  speed: 90,
+  startDelay: 300,
+  cursorAnimation: {
+    kind: 'combined',
+    duration: 900,
+  },
+})
+
+await typer
+  .type('Hi there!')
+  .pause(400)
+  .delete(6)
+  .type('untyper!')
+  .go()
 ```
-## Api
-#### type 
-> **Warning**: only support string
-> input 
-  - text `string` 
-  - opts: `object` { delay?: `number`, startDelay: `number`,
-  animationspancontent: `string`,
-  animate: {
-    cancel: `boolean`,
-  },}
-> output
-  - `this`
-#### pause 
-> input 
-  - ms `number` 
-> output
-  - `this`
-####  delete
-> input 
-  - charAt: `number` > 0
-  - opts: `object` -> delay?: `number`
-> output
-  - `this`
-#### move
-> input 
-  - movementArg: `number | null`
-  - opts?: `object`-> {to?: `string`, delay?: `number`}
-> output 
-  - `this`
-#### add
-> input
-  - text `string | HTMLElement` 
-  - opts: `object` -> delay?: `number`
-> output 
-  - `this`
 
-#### go
-> output
-  - `Promise`
+## API
+
+### `new UnTyper(element, options)`
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `speed` | `number` | `120` | Base delay between characters (ms). |
+| `startDelay` | `number` | `0` | Delay before the queue starts (ms). |
+| `animationspancontent` | `string` | `|` | Cursor character. |
+| `animate.cancel` | `boolean` | `false` | Hide cursor after the queue completes. |
+| `cursorAnimation` | `CursorAnimationOptions` | — | Cursor animation customization. |
+
+### `type(text, options)`
+Adds a plain text typing action. HTML is not supported here.
+
+- `text`: `string`
+- `options.delay`: optional delay (ms) after typing this text
+
+Returns `this`.
+
+### `pause(ms)`
+Adds a pause action.
+
+- `ms`: `number`
+
+Returns `this`.
+
+### `delete(charCount, options)`
+Deletes characters from the current cursor position.
+
+- `charCount`: `number` (must be greater than 0)
+- `options.delay`: optional delay (ms) after deleting
+
+Returns `this`.
+
+### `move(movementArg, options)`
+Moves the cursor.
+
+- `movementArg`: `number | null`
+  - Provide a negative number to move left by that many characters.
+  - Use `null` with `options.to = 'start' | 'end'` to jump to the start or end.
+
+Returns `this`.
+
+### `add(html, options)`
+Parses HTML and inserts elements with typing animation for text nodes. You can pass `options.animation` to animate inserted elements.
+
+- `html`: `string`
+- `options.delay`: optional delay (ms) after adding
+- `options.animation`: optional `ElementAnimation` to apply to added elements
+
+Returns `this`.
+
+### `image(src, options)`
+Inserts an `img` element with optional attributes. You can also pass `options.animation` to animate the image after insertion.
+
+- `src`: `string`
+- `options.alt`: `string`
+- `options.className`: `string`
+- `options.width`: `number`
+- `options.height`: `number`
+- `options.attrs`: `Record<string, string>` for additional attributes
+- `options.delay`: optional delay (ms) after inserting
+- `options.animation`: optional `ElementAnimation` to apply to the image
+
+Returns `this`.
+
+### `go()`
+Runs the queued actions.
+
+Returns `Promise<void>`.
+
+## Animation support
+You can apply custom animations to inserted DOM elements using `options.animation` on `add` or `image`.
+
+```ts
+await typer
+  .add('<strong>Spotlight</strong>', {
+    animation: {
+      keyframes: [
+        { opacity: 0, transform: 'translateY(4px)' },
+        { opacity: 1, transform: 'translateY(0)' },
+      ],
+      options: { duration: 300, easing: 'ease-out' },
+    },
+  })
+  .image('/logo.png', {
+    alt: 'Brand logo',
+    animation: {
+      keyframes: [
+        { transform: 'scale(0.9)', opacity: 0 },
+        { transform: 'scale(1)', opacity: 1 },
+      ],
+      options: { duration: 250 },
+    },
+  })
+  .go()
+```
 
 ## License
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,11 +17,6 @@ export interface ScopeData {
   cursorAnimation?: CursorAnimationOptions
 }
 
-export interface ActionOpts {
-  delay?: number
-  to?: 'start' | 'end'
-}
-
 export type CursorAnimationKind = 'opacity' | 'size' | 'gradient' | 'combined'
 
 export interface CursorAnimationOptions {
@@ -36,6 +31,25 @@ export interface CursorAnimationOptions {
     to?: string
     angle?: number
   }
+}
+
+export interface ElementAnimation {
+  keyframes: Keyframe[]
+  options?: KeyframeAnimationOptions
+}
+
+export interface ActionOpts {
+  delay?: number
+  to?: 'start' | 'end'
+  animation?: ElementAnimation
+}
+
+export interface ImageActionOpts extends ActionOpts {
+  alt?: string
+  className?: string
+  width?: number
+  height?: number
+  attrs?: Record<string, string>
 }
 
 export interface QueueItems {

--- a/test/untyper.test.ts
+++ b/test/untyper.test.ts
@@ -9,16 +9,69 @@ test('Element render correctly', async () => {
   document.body.appendChild(dom)
   dom.classList.add('typeText')
   const unTyper = new UnTyper(dom, {
-    speed: 100,
+    speed: 1,
+    startDelay: 0,
     animate: {
       cancel: false,
     },
   })
-  unTyper.type('type fn checked', {
-    delay: 1000,
-  }).go()
-  await new Promise(resolve => setTimeout(resolve, 2500))
+  await unTyper.type('type fn checked', { delay: 5 }).go()
   const element = document.querySelector('.typeText')
   expect(element).not.toBeNull()
   expect(element?.textContent).toMatchInlineSnapshot('"type fn checked|"')
+})
+
+/**
+ * @vitest-environment jsdom
+ */
+test('Supports chained operations', async () => {
+  const dom = document.createElement('div')
+  document.body.appendChild(dom)
+  const unTyper = new UnTyper(dom, {
+    speed: 1,
+    startDelay: 0,
+  })
+
+  await unTyper
+    .type('hello')
+    .pause(5)
+    .delete(2)
+    .type('y!')
+    .go()
+
+  expect(dom.textContent).toMatchInlineSnapshot('"hely!|"')
+})
+
+/**
+ * @vitest-environment jsdom
+ */
+test('Supports image insertion', async () => {
+  const dom = document.createElement('div')
+  document.body.appendChild(dom)
+  const unTyper = new UnTyper(dom, {
+    speed: 1,
+    startDelay: 0,
+  })
+
+  await unTyper
+    .type('Image: ')
+    .image('https://example.com/logo.png', {
+      alt: 'Brand',
+      className: 'brand-logo',
+      width: 120,
+      height: 60,
+      attrs: {
+        'data-track': 'hero',
+      },
+    })
+    .go()
+
+  const img = dom.querySelector('img')
+  expect(img).not.toBeNull()
+  expect(img?.getAttribute('src')).toBe('https://example.com/logo.png')
+  expect(img?.getAttribute('alt')).toBe('Brand')
+  expect(img?.getAttribute('class')).toBe('brand-logo')
+  expect(img?.getAttribute('width')).toBe('120')
+  expect(img?.getAttribute('height')).toBe('60')
+  expect(img?.getAttribute('data-track')).toBe('hero')
 })


### PR DESCRIPTION
### Motivation
- Enable inserting `img` elements via the UnTyper API and allow custom animations to be applied to inserted DOM nodes.
- Ensure elements that cannot host child nodes (void elements) are handled correctly to avoid inserting the cursor inside them.
- Provide a typed surface for image and animation options so callers can configure attributes and keyframe animations.
- Document usage and examples so consumers can use `image` and per-element `animation` options.

### Description
- Added new types in `src/types.ts`: `ElementAnimation`, `ImageActionOpts`, and extended `ActionOpts` to include `animation` options used by `add`/`image`.
- Implemented `image(src, opts)` in `src/untyper.ts` which builds an `img` element from `ImageActionOpts` and enqueues it via the existing DOM insertion path.
- Added `_applyAnimation` and `VOID_ELEMENTS` handling, and updated `_addDom` to avoid inserting the cursor into void elements and to apply per-element animations after insertion.
- Updated `README.md` with API documentation and examples, and added an image insertion test in `test/untyper.test.ts` to cover the new behavior.

### Testing
- Ran `npm test` (Vitest) against the updated test suite which includes image insertion and chained operation tests.
- All automated tests passed: `3 passed (3)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d3c6ad58832ea9b26fedebc2d4e0)